### PR TITLE
Update Export feature to use submission values if not set.

### DIFF
--- a/code/GenerateCSVJob.php
+++ b/code/GenerateCSVJob.php
@@ -236,7 +236,14 @@ class GenerateCSVJob extends AbstractQueuedJob {
      */
     public function process() {
         $gridField = $this->getGridField();
-        $columns = $this->Columns ?: singleton($gridField->getModelClass())->summaryFields();
+        
+        if($this->Columns) {
+            $columns = $this->Columns;
+        } else if($dataCols = $gridField->getConfig()->getComponentByType('GridFieldDataColumns')) {
+            $columns = $dataCols->getDisplayFields($gridField);
+        } else {
+            $columns = singleton($gridField->getModelClass())->summaryFields();
+        }
 
         if ($this->IncludeHeader && !$this->HeadersOutput) {
             $this->outputHeader($gridField, $columns);


### PR DESCRIPTION
When Exporting. The Bulk export feature will now attempt to use the submission values first before defaulting to Summary Values