### PR TITLE
FIX Add configurable sleep time before generation job completes to alleviate asset sync timing issues

### DIFF
--- a/code/GenerateCSVJob.php
+++ b/code/GenerateCSVJob.php
@@ -15,6 +15,15 @@
  */
 class GenerateCSVJob extends AbstractQueuedJob {
 
+    /**
+     * Optionally define the number of seconds to wait after the job has finished before marking it as complete.
+     * This can help in multi-server environments, where asset synchronisation may not be immediate.
+     *
+     * @config
+     * @var int
+     */
+    private static $sync_sleep_seconds = 0;
+
     public function __construct() {
         $this->ID = Injector::inst()->create('RandomGenerator')->randomToken('sha1');
         $this->Seperator = ',';
@@ -255,6 +264,11 @@ class GenerateCSVJob extends AbstractQueuedJob {
         $this->currentStep += 100;
 
         if ($this->currentStep >= $this->totalSteps) {
+            // Check to see if we need to wait for some time for asset synchronisation to complete
+            $sleepTime = (int) Config::inst()->get('GenerateCSVJob', 'sync_sleep_seconds');
+            if ($sleepTime > 0) {
+                sleep($sleepTime);
+            }
             $this->isComplete = true;
         }
     }

--- a/tests/GenerateCSVJobTest.php
+++ b/tests/GenerateCSVJobTest.php
@@ -11,6 +11,7 @@ class GenerateCSVJobTest extends SapphireTest {
         Config::inst()->update('Director', 'rules', array(
             'jobtest//$Action/$ID/$OtherID' => 'GenerateCSVJobTest_Controller'
         ));
+        Config::inst()->update('GenerateCSVJob', 'sync_sleep_seconds', 0);
     }
 
     protected $paths = array();


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-gridfieldqueuedexport/issues/32