### PR TITLE
FIX Add configurable sleep time before generation job completes to alleviate asset sync timing issues

### DIFF
--- a/tests/GenerateCSVJobTest.php
+++ b/tests/GenerateCSVJobTest.php
@@ -22,9 +22,11 @@ class GenerateCSVJobTest extends SapphireTest
     {
         parent::setUp();
 
-        Config::modify()->merge(Director::class, 'rules', [
-            'jobtest//$Action/$ID/$OtherID' => GenerateCSVJobTestController::class
-        ]);
+        Config::modify()
+            ->merge(Director::class, 'rules', [
+                'jobtest//$Action/$ID/$OtherID' => GenerateCSVJobTestController::class
+            ])
+            ->set(GenerateCSVJob::class, 'sync_sleep_seconds', 0);
     }
 
     protected $paths = [];


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-gridfieldqueuedexport/issues/32