### PR TITLE
Add psr4 autoload info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,11 @@
             "client"
         ]
     },
+    "autoload": {
+        "psr-4": {
+            "SilverStripe\\GridfieldQueuedExport\\": "src/"
+        }
+    },
     "prefer-stable": true
 }
 


### PR DESCRIPTION
This helps other tools like phpstan work in the presence of this module
without having to introduce this information into the larger project's
composer.json.