### PR TITLE
Update Travis matrix to include SS ^4.2 and PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,24 @@
 language: php
 
-env:
-  global:
-    - COMPOSER_ROOT_VERSION="2.0.x-dev"
-
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL PHPUNIT_TEST=1
+      env: DB=PGSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
-      env: DB=MYSQL PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+    - php: 7.3
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
   - phpenv rehash
   - phpenv config-rm xdebug.ini
 
   - composer validate
-  - if [[ $DB == "PGSQL" ]]; then composer require --no-update silverstripe/postgresql 2.1.x-dev; fi
+  - if [[ $DB == "PGSQL" ]]; then composer require --no-update silverstripe/recipe-core:"$RECIPE_VERSION" silverstripe/postgresql:2.2.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/tests/GenerateCSVJobTest.php
+++ b/tests/GenerateCSVJobTest.php
@@ -64,14 +64,15 @@ class GenerateCSVJobTest extends SapphireTest
 
         // Test that the output matches the expected
         $expected = [
-            'Title,Content,"Publish On"',
             '"Record 1","<p>""Record 1"" Body</p>","2015-01-01 23:34:01"',
             '"Record 2","<p>""Record 2"" Body</p>","2015-01-02 23:34:01"',
             '"Record 3","<p>""Record 3"" Body</p>","2015-01-03 23:34:01"',
             '',
         ];
         $actual = file_get_contents($path);
-        $this->assertEquals(implode("\r\n", $expected), $actual);
+        // Note: strtolower() is for case insensitive comparison, since field label casing changed in SS 4.3
+        $this->assertContains('title,content,"publish on"', strtolower($actual));
+        $this->assertContains(implode("\r\n", $expected), $actual);
     }
 
     public function testGenerateExportOverMultipleSteps()
@@ -111,14 +112,15 @@ class GenerateCSVJobTest extends SapphireTest
 
         // Test that the output matches the expected
         $expected = [
-            'Title,Content,"Publish On"',
             '"Record 1","<p>""Record 1"" Body</p>","2015-01-01 23:34:01"',
             '"Record 2","<p>""Record 2"" Body</p>","2015-01-02 23:34:01"',
             '"Record 3","<p>""Record 3"" Body</p>","2015-01-03 23:34:01"',
             '',
         ];
         $actual = file_get_contents($path);
-        $this->assertEquals(implode("\r\n", $expected), $actual);
+        // Note: strtolower() is for case insensitive comparison, since field label casing changed in SS 4.3
+        $this->assertContains('title,content,"publish on"', strtolower($actual));
+        $this->assertContains(implode("\r\n", $expected), $actual);
     }
 
     /**


### PR DESCRIPTION
Label casing changed in SilverStripe 4.3. Rather than bake in logic about which version is running I figured a case insensitive check on the field labels was OK.

Fixes #38