### PR TITLE
lose the filters when using SS report

### DIFF
--- a/src/Jobs/GenerateCSVJob.php
+++ b/src/Jobs/GenerateCSVJob.php
@@ -127,6 +127,7 @@ class GenerateCSVJob extends AbstractQueuedJob
         $this->GridFieldURL = $gridField->Link();
         $this->GridFieldState = $gridField->getState()->toArray();
         $this->totalSteps = $gridField->getManipulatedList()->count();
+        $this->Filters = Controller::curr()->getRequest()->getVar('filters');
 
         return $this;
     }
@@ -280,9 +281,18 @@ class GenerateCSVJob extends AbstractQueuedJob
         $actionKey = 'action_gridFieldAlterAction?' . http_build_query(['StateID' => $id]);
         $actionValue = 'Find Gridfield';
 
+        $queryParams = [$actionKey => $actionValue, 'SecurityID' => $token];
+
+        // Get the filters and assign to the url as a get parameter
+        if (is_array($this->Filters) && count($this->Filters) > 0) {
+            foreach ($this->Filters as $filter => $value) {
+                $queryParams['filters'][$filter] = $value;
+            }
+        }
+
         $url = Controller::join_links(
             $this->GridFieldURL,
-            '?' . http_build_query([$actionKey => $actionValue, 'SecurityID' => $token])
+            '?' . http_build_query($queryParams)
         );
 
         // Restore into the current session the user the job is exporting as


### PR DESCRIPTION
Issue:  lose the filters when using SS report.

Expected behaviour: Export CSV matches the displayed list (filtered records only)
Actual behaviour: All records are exports.


````
use SilverStripe\Reports\Report;
use SilverStripe\Forms\FieldList;
use SilverStripe\Forms\TextField;
use SilverStripe\Security\Member;
use SilverStripe\Forms\GridField\GridFieldExportButton;
use SilverStripe\GridfieldQueuedExport\Forms\GridFieldQueuedExportButton;

class TestReport extends Report
{

    public function parameterFields()
    {
        return new FieldList(
            TextField::create('Surname')
        );
    }

    public function sourceRecords($params = [])
    {
        $members = Member::get();

        if (isset($params['Surname'])) {
            $members = $members->filter('Surname', $params['Surname']);
        }

        return $members;
    }

    public function columns()
    {
        return [
            "FirstName" => [
                'title' => 'First name'
            ],
            "Surname" => [
                'title' => 'Surname'
            ],
            "Email" => [
                'title' => 'Email',
            ]
        ];
    }


    /**
     * @return FormField
     */
    public function getReportField()
    {
        $gridField = parent::getReportField();
        $config = $gridField->getConfig();

        $oldExportButton = $config->getComponentByType(GridFieldExportButton::class);
        $config->addComponent($newExportButton = GridFieldQueuedExportButton::create('buttons-before-left'));

        $newExportButton->setCsvHasHeader($oldExportButton->getCsvHasHeader());

        $config->removeComponentsByType(GridFieldExportButton::class);


        return $gridField;
    }

}

````