### PR TITLE
Fix for issue #47 If stalled job restarts, the already exported data is overwritten

### DIFF
--- a/src/Jobs/GenerateCSVJob.php
+++ b/src/Jobs/GenerateCSVJob.php
@@ -227,7 +227,6 @@ class GenerateCSVJob extends AbstractQueuedJob
             $csvWriter = Writer::createFromPath($this->getOutputPath(), 'a');
 
             $csvWriter->setDelimiter($this->Seperator);
-            $csvWriter->setNewline("");
             $csvWriter->setOutputBOM(Writer::BOM_UTF8);
 
             if (!Config::inst()->get(GridFieldExportButton::class, 'xls_export_disabled')) {

--- a/src/Jobs/GenerateCSVJob.php
+++ b/src/Jobs/GenerateCSVJob.php
@@ -224,10 +224,10 @@ class GenerateCSVJob extends AbstractQueuedJob
     protected function getCSVWriter()
     {
         if (!$this->writer) {
-            $csvWriter = Writer::createFromPath($this->getOutputPath(), 'w');
+            $csvWriter = Writer::createFromPath($this->getOutputPath(), 'a');
 
             $csvWriter->setDelimiter($this->Seperator);
-            $csvWriter->setNewline("\r\n"); //use windows line endings for compatibility with some csv libraries
+            $csvWriter->setNewline("");
             $csvWriter->setOutputBOM(Writer::BOM_UTF8);
 
             if (!Config::inst()->get(GridFieldExportButton::class, 'xls_export_disabled')) {


### PR DESCRIPTION
Issue #47 
If an export job stalls and restarts the CSV writer overwrites the file resulting in an export only containing the records from the last (re)start and no header row.
By changing the mode to append instead of write every record (even after a restart of the job) is appended on a new line. Because of that, the setNewLine has to be reset to empty otherwise there is an extra empty line between each record in the file.