### PR TITLE
MNT Remove branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,7 @@
     "extra": {
         "expose": [
             "client"
-        ],
-        "branch-alias": {
-            "dev-master": "2.x-dev"
-        }
+        ]
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Build is expected to fail, `master` branch is behind the default `2` branch.

This PR is just to break the composer link between the two branches so that the `master` branch does not get installed when requiring `2.x-dev`

