### PR TITLE
MNT Use GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  # Every Wednesday at 2:20pm UTC
+  schedule:
+    - cron: '20 14 * * 3'
+
+jobs:
+  ci:
+    name: CI
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && startsWith(github.repository, 'silverstripe/')) || (github.event_name != 'schedule')
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,17 @@
+name: Keepalive
+
+on:
+  workflow_dispatch:
+  # The 4th of every month at 10:50am UTC
+  schedule:
+    - cron: '50 10 4 * *'
+
+jobs:
+  keepalive:
+    name: Keepalive
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && startsWith(github.repository, 'silverstripe/')) || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Keepalive
+        uses: silverstripe/gha-keepalive@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GridField Queued Export
 
-[![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-gridfieldqueuedexport.svg?branch=2)](https://travis-ci.com/silverstripe/silverstripe-gridfieldqueuedexport)
+[![CI](https://github.com/silverstripe/silverstripe-gridfieldqueuedexport/actions/workflows/ci.yml/badge.svg)](https://github.com/silverstripe/silverstripe-gridfieldqueuedexport/actions/workflows/ci.yml)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/silverstripe-gridfieldqueuedexport/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/silverstripe-gridfieldqueuedexport/?branch=master)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
 [![Code Coverage](https://codecov.io/gh/silverstripe/silverstripe-gridfieldqueuedexport/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/silverstripe-gridfielqueuedexport)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3 || ^8.0",
         "league/csv": "^8 || ^9",
         "silverstripe/framework": "^4.10",
-        "symbiote/silverstripe-queuedjobs": "^4"
+        "symbiote/silverstripe-queuedjobs": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11<br /><br />Workflow run https://github.com/creative-commoners/silverstripe-gridfieldqueuedexport/actions?query=branch%3Apulls%2F2.6%2Fmodule-standards

^4.1 of queuedjobs is because that was the minimum version to get the Injectable trait to fix the --prefer-lowest build
`[2022-07-05 07:00:51] error-log.ERROR: Uncaught Exception Error: "Call to undefined method Symbiote\QueuedJobs\Services\QueuedJobService::singleton()`
https://github.com/creative-commoners/silverstripe-gridfieldqueuedexport/runs/7191389471?check_suite_focus=true