### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "league/csv": "^8 || ^9",
-        "silverstripe/framework": "4.13.x-dev",
-        "symbiote/silverstripe-queuedjobs": "4.12.x-dev"
+        "silverstripe/framework": "^4.10",
+        "symbiote/silverstripe-queuedjobs": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33